### PR TITLE
#132 404 Not Found for unregistered APIs

### DIFF
--- a/src/main/java/me/sitech/apifort/processor/GatewayExceptionHandlerProcessor.java
+++ b/src/main/java/me/sitech/apifort/processor/GatewayExceptionHandlerProcessor.java
@@ -3,6 +3,10 @@ package me.sitech.apifort.processor;
 import io.opentelemetry.api.trace.Span;
 import lombok.extern.slf4j.Slf4j;
 import me.sitech.apifort.constant.ApiFort;
+import me.sitech.apifort.constant.ApiFortStatusCode;
+import me.sitech.apifort.domain.response.common.ErrorRes;
+import me.sitech.apifort.exceptions.APIFortGeneralException;
+import me.sitech.apifort.exceptions.ApiFortInvalidEndpoint;
 import org.apache.camel.Exchange;
 import org.apache.camel.Processor;
 
@@ -17,8 +21,12 @@ public class GatewayExceptionHandlerProcessor implements Processor {
     @Override
     public void process(Exchange exchange) throws Exception {
         final Throwable ex = exchange.getProperty(Exchange.EXCEPTION_CAUGHT, Throwable.class);
-
         String traceId = Span.current().getSpanContext().getTraceId();
+
+        if(ex instanceof ApiFortInvalidEndpoint || ex instanceof APIFortGeneralException){
+            exchange.getIn().setHeader(Exchange.HTTP_RESPONSE_CODE, ApiFortStatusCode.BAD_REQUEST);
+            exchange.getIn().setBody(new ErrorRes(traceId,ex.getMessage()));
+        }
         exchange.getIn().setHeader(ApiFort.APIFORT_TRACE_ID, traceId);
         exchange.getIn().removeHeader(APIFORT_DOWNSTREAM_SERVICE_HEADER);
 


### PR DESCRIPTION
#132 Add 404 response code when API not registered in the system